### PR TITLE
Enforce build android 16 kb alignment

### DIFF
--- a/.github/workflows/build_android.yml
+++ b/.github/workflows/build_android.yml
@@ -36,6 +36,12 @@ jobs:
         run: cargo ndk -t armeabi-v7a -t arm64-v8a -t x86 -t x86_64 -o android-libs-build build --features android --release
         working-directory: ./libDF
 
+      - name: Verify built .so files 16 kb alignment
+        run: |
+          LLVM_READELF_PATH=$(find $ANDROID_NDK_HOME -name llvm-readelf | head -n 1)
+          $LLVM_READELF_PATH -l android-libs-build/arm64-v8a/libdf.so | grep 'R E' | grep '0x4000$' || (echo "Alignment check failed for arm64-v8a" && exit 1)
+        working-directory: ./libDF
+
       - name: Upload native Android libraries
         uses: actions/upload-artifact@v4
         with:

--- a/libDF/.cargo/config.toml
+++ b/libDF/.cargo/config.toml
@@ -1,0 +1,11 @@
+[target.aarch64-linux-android]
+rustflags = ["-C", "link-arg=-Wl,-z,max-page-size=16384"]
+
+[target.armv7-linux-androideabi]
+rustflags = ["-C", "link-arg=-Wl,-z,max-page-size=16384"]
+
+[target.i686-linux-android]
+rustflags = ["-C", "link-arg=-Wl,-z,max-page-size=16384"]
+
+[target.x86_64-linux-android]
+rustflags = ["-C", "link-arg=-Wl,-z,max-page-size=16384"]


### PR DESCRIPTION
This PR adds the necessary configuration to enforce 16KB alignment, which will be required starting November 2025 to publish apps on the Google Play Store with full support for Android 15.

The following updates have been made:

1. A `config.toml` file has been added to the `/libDF/.cargo` directory to instruct the linker to align the generated `.so` files to 16KB. This ensures that Cargo consistently produces 16KB-aligned binaries, regardless of the build environment.

2. A validation step has been added to `build_android.yml` to verify that the generated `.so` files are properly aligned to 16KB. If they are not, the workflow will fail.
